### PR TITLE
specifying `_pd_read_kwds` for unemployment and zipcodes datasets

### DIFF
--- a/vega_datasets/core.py
+++ b/vega_datasets/core.py
@@ -342,6 +342,11 @@ class Sp500(Dataset):
     _pd_read_kwds = {'parse_dates': ['date']}
 
 
+class Unemployment(Dataset):
+    name = 'unemployment'
+    _pd_read_kwds = {'sep': '\t'}
+
+
 class UnemploymentAcrossIndustries(Dataset):
     name = 'unemployment-across-industries'
     _pd_read_kwds = {'convert_dates': ['date']}
@@ -371,6 +376,11 @@ class World_110M(Dataset):
     def __call__(self, use_local=True, **kwargs):
         __doc__ = super(World_110M, self).__call__.__doc__
         return json.loads(bytes_decode(self.raw(use_local=use_local)), **kwargs)
+
+
+class ZIPCodes(Dataset):
+    name = 'zipcodes'
+    _pd_read_kwds = {'dtype': {'zip_code': 'category'}}
 
 
 class DataLoader(object):

--- a/vega_datasets/core.py
+++ b/vega_datasets/core.py
@@ -375,7 +375,7 @@ class World_110M(Dataset):
 
 class ZIPCodes(Dataset):
     name = 'zipcodes'
-    _pd_read_kwds = {'dtype': {'zip_code': 'category'}}
+    _pd_read_kwds = {'dtype': {'zip_code': 'object'}}
 
 
 class DataLoader(object):

--- a/vega_datasets/core.py
+++ b/vega_datasets/core.py
@@ -342,11 +342,6 @@ class Sp500(Dataset):
     _pd_read_kwds = {'parse_dates': ['date']}
 
 
-class Unemployment(Dataset):
-    name = 'unemployment'
-    _pd_read_kwds = {'sep': '\t'}
-
-
 class UnemploymentAcrossIndustries(Dataset):
     name = 'unemployment-across-industries'
     _pd_read_kwds = {'convert_dates': ['date']}

--- a/vega_datasets/tests/test_download.py
+++ b/vega_datasets/tests/test_download.py
@@ -55,3 +55,12 @@ def test_us_10m_parsing():
 def test_world_110m_parsing():
     world_110m = data.world_110m()
     assert type(world_110m) is dict
+
+
+@skip_if_no_internet
+def test_zipcodes_parsing():
+    zipcodes = data.zipcodes()
+    assert all(zipcodes.columns == ['zip_code', 'latitude', 'longitude',
+                                    'city', 'state', 'county'])
+    assert all(zipcodes.dtypes == ['object', 'float64', 'float64',
+                                   'object', 'object', 'object'])


### PR DESCRIPTION
Addressing issue #16 

This commit specifies the separator (tab) for the `unemployment` data and `dtype` for `zip_code` variable in `zipcodes` dataset. 