### PR TITLE
TST: fix tests for pandas 0.25

### DIFF
--- a/vega_datasets/tests/test_download.py
+++ b/vega_datasets/tests/test_download.py
@@ -14,8 +14,8 @@ skip_if_no_internet = pytest.mark.skipif(not connection_ok(),
 def test_download_iris():
     iris = data.iris(use_local=False)
     assert type(iris) is pd.DataFrame
-    assert tuple(iris.columns) == ('petalLength', 'petalWidth', 'sepalLength',
-                                   'sepalWidth', 'species')
+    assert sorted(iris.columns) == ['petalLength', 'petalWidth', 'sepalLength',
+                                    'sepalWidth', 'species']
 
     iris = data.iris.raw(use_local=False)
     assert type(iris) is bytes
@@ -29,7 +29,7 @@ def test_stock_date_parsing():
 def test_stock_pivoted():
     stocks = data.stocks(pivoted=True)
     assert stocks.index.name == 'date'
-    assert all(stocks.columns == ['AAPL', 'AMZN', 'GOOG', 'IBM', 'MSFT'])
+    assert sorted(stocks.columns) == ['AAPL', 'AMZN', 'GOOG', 'IBM', 'MSFT']
 
 
 @skip_if_no_internet

--- a/vega_datasets/tests/test_local_datasets.py
+++ b/vega_datasets/tests/test_local_datasets.py
@@ -29,8 +29,8 @@ def test_load_local_dataset(name):
 def test_iris_column_names():
     iris = data.iris()
     assert type(iris) is pd.DataFrame
-    assert tuple(iris.columns) == ('petalLength', 'petalWidth', 'sepalLength',
-                                   'sepalWidth', 'species')
+    assert sorted(iris.columns) == ['petalLength', 'petalWidth', 'sepalLength',
+                                    'sepalWidth', 'species']
 
     iris = data.iris.raw()
     assert type(iris) is bytes
@@ -39,7 +39,7 @@ def test_iris_column_names():
 def test_stocks_column_names():
     stocks = data.stocks()
     assert type(stocks) is pd.DataFrame
-    assert tuple(stocks.columns) == ('symbol', 'date', 'price')
+    assert sorted(stocks.columns) == ['date', 'price', 'symbol']
 
     stocks = data.stocks.raw()
     assert type(stocks) is bytes
@@ -48,9 +48,9 @@ def test_stocks_column_names():
 def test_cars_column_names():
     cars = data.cars()
     assert type(cars) is pd.DataFrame
-    assert tuple(cars.columns) == ('Acceleration', 'Cylinders', 'Displacement',
+    assert sorted(cars.columns) == ['Acceleration', 'Cylinders', 'Displacement',
                                    'Horsepower', 'Miles_per_Gallon', 'Name',
-                                   'Origin', 'Weight_in_lbs', 'Year')
+                                   'Origin', 'Weight_in_lbs', 'Year']
 
     cars = data.cars.raw()
     assert type(cars) is bytes


### PR DESCRIPTION
Fixes #24

The issue seems to be linked to changes in how Pandas parses JSON files; columns previously were sorted, now they appear in the same order as in the file. It's not obvious from pandas 0.25 [release notes](https://pandas.pydata.org/pandas-docs/version/0.25/whatsnew/v0.25.0.html) whether this is intentional, but either way this PR makes the tests robust to that.