### PR TITLE
Prepare for v0.9 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,10 @@
 Change Log
 ==========
 
-Release v0.9 (unreleased)
--------------------------
+Release v0.9 (Nov 26, 2020)
+---------------------------
 - Change urls to use jsDelivr (a fast CDN) with a fixed version number, instead of GitHub.
+  This fixes the URLs broken by the vega-datasets 2.0 release.
 
 Release v0.8 (Dec 14, 2019)
 ---------------------------

--- a/vega_datasets/__init__.py
+++ b/vega_datasets/__init__.py
@@ -2,4 +2,4 @@ from vega_datasets.core import DataLoader, LocalDataLoader
 
 data = DataLoader()
 local_data = LocalDataLoader()
-__version__ = "0.9.0dev0"
+__version__ = "0.9.0"


### PR DESCRIPTION
This release will fix the URLs broken by vega-datasets 2.0. We'll have to add new datasets in a new release.